### PR TITLE
Fix NoClassDefFoundError

### DIFF
--- a/src/com/squareup/ideaplugin/dagger/ShowUsagesAction.java
+++ b/src/com/squareup/ideaplugin/dagger/ShowUsagesAction.java
@@ -81,6 +81,7 @@ import com.intellij.ui.TableScrollingUtil;
 import com.intellij.ui.TableUtil;
 import com.intellij.ui.awt.RelativePoint;
 import com.intellij.ui.popup.AbstractPopup;
+import com.intellij.ui.table.JBTable;
 import com.intellij.usageView.UsageViewBundle;
 import com.intellij.usages.PsiElementUsageTarget;
 import com.intellij.usages.Usage;
@@ -1105,7 +1106,7 @@ public class ShowUsagesAction extends AnAction implements PopupAction {
     return newFileEditor instanceof TextEditor ? ((TextEditor) newFileEditor).getEditor() : null;
   }
 
-  private static class MyTable extends com.intellij.ui.table.JBTable implements DataProvider {
+  private static class MyTable extends JBTable implements DataProvider {
     @Override
     public boolean getScrollableTracksViewportWidth() {
       return true;

--- a/src/com/squareup/ideaplugin/dagger/ShowUsagesAction.java
+++ b/src/com/squareup/ideaplugin/dagger/ShowUsagesAction.java
@@ -74,7 +74,6 @@ import com.intellij.psi.search.PsiElementProcessor;
 import com.intellij.psi.search.SearchScope;
 import com.intellij.ui.ActiveComponent;
 import com.intellij.ui.InplaceButton;
-import com.intellij.ui.JBTableWithHintProvider;
 import com.intellij.ui.ScreenUtil;
 import com.intellij.ui.SpeedSearchBase;
 import com.intellij.ui.SpeedSearchComparator;
@@ -1106,7 +1105,7 @@ public class ShowUsagesAction extends AnAction implements PopupAction {
     return newFileEditor instanceof TextEditor ? ((TextEditor) newFileEditor).getEditor() : null;
   }
 
-  private static class MyTable extends JBTableWithHintProvider implements DataProvider {
+  private static class MyTable extends com.intellij.ui.table.JBTable implements DataProvider {
     @Override
     public boolean getScrollableTracksViewportWidth() {
       return true;
@@ -1123,7 +1122,7 @@ public class ShowUsagesAction extends AnAction implements PopupAction {
       return null;
     }
 
-    @Override @Nullable
+    @Nullable
     protected PsiElement getPsiElementForHint(Object selectedValue) {
       if (selectedValue instanceof UsageNode) {
         final Usage usage = ((UsageNode) selectedValue).getUsage();


### PR DESCRIPTION
This fixes the noclassdef found error as the JBTableHintProvider was
removed in IDEA 2016.1.  This replaces it with the ui.JBTable class
and it seems to work as expected.

This fixes issue #19.