### PR TITLE
Updates behavior of plugin in several ways:

### DIFF
--- a/src/com/squareup/ideaplugin/dagger/InjectionLineMarkerProvider.java
+++ b/src/com/squareup/ideaplugin/dagger/InjectionLineMarkerProvider.java
@@ -19,6 +19,7 @@ import org.jetbrains.annotations.Nullable;
 import static com.intellij.codeHighlighting.Pass.UPDATE_ALL;
 import static com.intellij.openapi.editor.markup.GutterIconRenderer.Alignment.LEFT;
 import static com.squareup.ideaplugin.dagger.DaggerConstants.CLASS_INJECT;
+import static com.squareup.ideaplugin.dagger.DaggerConstants.CLASS_PROVIDES;
 
 public class InjectionLineMarkerProvider implements LineMarkerProvider {
   private static final Icon ICON = IconLoader.getIcon("/icons/inject.png");
@@ -39,11 +40,22 @@ public class InjectionLineMarkerProvider implements LineMarkerProvider {
       PsiMethod methodElement = (PsiMethod) element;
 
       // Constructor injection.
-      if (methodElement.isConstructor() && PsiConsultantImpl.hasAnnotation(element, CLASS_INJECT)) {
+      if (methodElement.isConstructor() && PsiConsultantImpl.hasAnnotation(element, CLASS_INJECT) &&
+              methodElement.getParameterList().getParametersCount() > 0) {
         PsiIdentifier nameIdentifier = methodElement.getNameIdentifier();
         if (nameIdentifier != null) {
           return new LineMarkerInfo<PsiElement>(element, nameIdentifier.getTextRange(), ICON,
               UPDATE_ALL, null, new ConstructorInjectToProvidesHandler(), LEFT);
+        }
+      }
+
+      // Method annotated with @Provides and has at least one argument
+      if (!methodElement.isConstructor() && PsiConsultantImpl.hasAnnotation(element, CLASS_PROVIDES) &&
+              methodElement.getParameterList().getParametersCount() > 0) {
+        PsiIdentifier nameIdentifier = methodElement.getNameIdentifier();
+        if (nameIdentifier != null) {
+          return new LineMarkerInfo<PsiElement>(element, nameIdentifier.getTextRange(), ICON,
+                  UPDATE_ALL, null, new ConstructorInjectToProvidesHandler(), LEFT);
         }
       }
 

--- a/src/com/squareup/ideaplugin/dagger/handler/ConstructorInjectToProvidesHandler.java
+++ b/src/com/squareup/ideaplugin/dagger/handler/ConstructorInjectToProvidesHandler.java
@@ -1,17 +1,23 @@
 package com.squareup.ideaplugin.dagger.handler;
 
 import com.intellij.codeInsight.daemon.GutterIconNavigationHandler;
+import com.intellij.pom.Navigatable;
+import com.intellij.psi.JavaPsiFacade;
+import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiMethod;
 import com.intellij.psi.PsiParameter;
+import com.intellij.psi.PsiTypeElement;
 import com.intellij.psi.util.PsiUtilBase;
 import com.intellij.ui.awt.RelativePoint;
 import com.squareup.ideaplugin.dagger.Decider;
 import com.squareup.ideaplugin.dagger.PickTypeAction;
 import com.squareup.ideaplugin.dagger.PsiConsultantImpl;
 import com.squareup.ideaplugin.dagger.ShowUsagesAction;
+
 import java.awt.event.MouseEvent;
 
+import static com.squareup.ideaplugin.dagger.DaggerConstants.CLASS_INJECT;
 import static com.squareup.ideaplugin.dagger.DaggerConstants.MAX_USAGES;
 
 /**
@@ -27,10 +33,6 @@ public class ConstructorInjectToProvidesHandler implements GutterIconNavigationH
     }
 
     PsiMethod psiMethod = (PsiMethod) psiElement;
-    if (!psiMethod.isConstructor()) {
-      throw new IllegalStateException("Called with non-constructor: " + psiElement);
-    }
-
     PsiParameter[] parameters = psiMethod.getParameterList().getParameters();
     if (parameters.length == 1) {
       showUsages(mouseEvent, parameters[0]);
@@ -45,8 +47,40 @@ public class ConstructorInjectToProvidesHandler implements GutterIconNavigationH
   }
 
   private void showUsages(MouseEvent mouseEvent, PsiParameter psiParameter) {
+    // Check to see if class type of psiParameter has constructor with @Inject. Otherwise, proceed.
+    if (navigateToConstructorIfProvider(psiParameter)) {
+      return;
+    }
     new ShowUsagesAction(new Decider.ConstructorParameterInjectDecider(psiParameter)).startFindUsages(
         PsiConsultantImpl.checkForLazyOrProvider(psiParameter), new RelativePoint(mouseEvent),
         PsiUtilBase.findEditor(psiParameter), MAX_USAGES);
+  }
+
+  private boolean navigateToConstructorIfProvider(PsiParameter psiParameter) {
+    PsiTypeElement declaringTypeElement = psiParameter.getTypeElement();
+    PsiClass classElement = JavaPsiFacade.getInstance(psiParameter.getProject()).findClass(
+            declaringTypeElement.getType().getCanonicalText(),
+            declaringTypeElement.getResolveScope());
+
+    if (classElement == null) {
+      return false;
+    }
+
+    for (PsiMethod method : classElement.getConstructors()) {
+      if (PsiConsultantImpl.hasAnnotation(method, CLASS_INJECT) && navigateToElement(method)) {
+          return true;
+      }
+    }
+    return false;
+  }
+
+  private boolean navigateToElement(PsiElement element) {
+    PsiElement navigationElement = element.getNavigationElement();
+    if (navigationElement != null && navigationElement instanceof Navigatable &&
+            ((Navigatable) navigationElement).canNavigate()) {
+      ((Navigatable) navigationElement).navigate(true);
+      return true;
+    }
+    return false;
   }
 }


### PR DESCRIPTION
- An "Inject" icon appears for methods annotated with @Provides containing more than 1 argument.
This allows users to click the icon to find where the given type was injected from.
- An "Inject" icon no longer appears for methods annotated with @Inject having no arguments.
No dependencies are injected into empty constructors annotated with @Inject. Those only serve as providers.
- Fixes searching for injections where there is no corresponding @Provides but there exists a constructor
denoted with @Inject.
- When searching a @Provides statement for where it is injected, results are fixed to include injections in the parameter list of other @Provides statements.

Details on changes:

- Updates Decider class to be cleaner and take in the PsiElement so to enable flexibility of deriving additional information from the class later.
- Updates InjectionLineMakerProvider so that constructors with @Inject annotation must have at least 1 argument for the inject icon to appear.
- Updates InjectionLineMakerProvider so that methods with @Provides annotation and at least 1 argument have an inject icon appear.
- Updates ConstructorInjectToProvidesHandler to search for constructors with @Inject annotation first. If none exists, continues with usage search
to find injection source.
- This patch updates ProvidesMethodDecider such that methods annotated with @Provides are also included in the search for injections.