### PR TITLE
Enables searching for @Provide(type=SET) injection points

### DIFF
--- a/src/com/squareup/ideaplugin/dagger/DaggerConstants.java
+++ b/src/com/squareup/ideaplugin/dagger/DaggerConstants.java
@@ -6,6 +6,9 @@ public interface DaggerConstants {
   String CLASS_LAZY = "dagger.Lazy";
   String CLASS_PROVIDER = "javax.inject.Provider";
   String CLASS_QUALIFIER = "javax.inject.Qualifier";
+  String ATTRIBUTE_TYPE = "type";
+  String SET_TYPE = "SET";
+  String MAP_TYPE = "MAP";
 
   int MAX_USAGES = 100;
 }

--- a/src/com/squareup/ideaplugin/dagger/PsiConsultantImpl.java
+++ b/src/com/squareup/ideaplugin/dagger/PsiConsultantImpl.java
@@ -3,11 +3,12 @@ package com.squareup.ideaplugin.dagger;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.JavaPsiFacade;
 import com.intellij.psi.PsiAnnotation;
+import com.intellij.psi.PsiAnnotationMemberValue;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiClassType;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiElementFactory;
 import com.intellij.psi.PsiField;
-import com.intellij.psi.PsiJavaCodeReferenceElement;
 import com.intellij.psi.PsiMethod;
 import com.intellij.psi.PsiModifierList;
 import com.intellij.psi.PsiModifierListOwner;
@@ -15,16 +16,19 @@ import com.intellij.psi.PsiParameter;
 import com.intellij.psi.PsiType;
 import com.intellij.psi.PsiVariable;
 import com.intellij.psi.search.GlobalSearchScope;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static com.squareup.ideaplugin.dagger.DaggerConstants.ATTRIBUTE_TYPE;
 import static com.squareup.ideaplugin.dagger.DaggerConstants.CLASS_LAZY;
 import static com.squareup.ideaplugin.dagger.DaggerConstants.CLASS_PROVIDER;
+import static com.squareup.ideaplugin.dagger.DaggerConstants.CLASS_PROVIDES;
 import static com.squareup.ideaplugin.dagger.DaggerConstants.CLASS_QUALIFIER;
+import static com.squareup.ideaplugin.dagger.DaggerConstants.MAP_TYPE;
+import static com.squareup.ideaplugin.dagger.DaggerConstants.SET_TYPE;
 
 public class PsiConsultantImpl {
 
@@ -45,7 +49,6 @@ public class PsiConsultantImpl {
         }
       }
     }
-
     return null;
   }
 
@@ -107,6 +110,15 @@ public class PsiConsultantImpl {
     return null;
   }
 
+  public static PsiAnnotationMemberValue findTypeAttributeOfProvidesAnnotation(
+      PsiElement element ) {
+    PsiAnnotation annotation = findAnnotation(element, CLASS_PROVIDES);
+    if (annotation != null) {
+      return annotation.findAttributeValue(ATTRIBUTE_TYPE);
+    }
+    return null;
+  }
+
   public static PsiClass getReturnClassFromMethod(PsiMethod psiMethod) {
     if (psiMethod.isConstructor()) {
       return psiMethod.getContainingClass();
@@ -114,6 +126,23 @@ public class PsiConsultantImpl {
 
     PsiClassType returnType = ((PsiClassType) psiMethod.getReturnType());
     if (returnType != null) {
+
+      // Check if has @Provides annotation and specified type
+      PsiAnnotationMemberValue attribValue = findTypeAttributeOfProvidesAnnotation(psiMethod);
+      if (attribValue != null) {
+        if (attribValue.textMatches(SET_TYPE)) {
+          String typeName = "java.util.Set<" + returnType.getCanonicalText() + ">";
+          returnType = ((PsiClassType) PsiElementFactory.SERVICE.getInstance(psiMethod.getProject())
+              .createTypeFromText(typeName, psiMethod));
+        } else if (attribValue.textMatches(MAP_TYPE)) {
+          // TODO(radford): Supporting map will require fetching the key type and also validating
+          // the qualifier for the provided key.
+          //
+          // String typeName = "java.util.Map<String, " + returnType.getCanonicalText() + ">";
+          // returnType = ((PsiClassType) PsiElementFactory.SERVICE.getInstance(psiMethod.getProject())
+          //    .createTypeFromText(typeName, psiMethod));
+        }
+      }
       return returnType.resolve();
     }
     return null;
@@ -176,6 +205,24 @@ public class PsiConsultantImpl {
     PsiClassType psiClassType = getPsiClassType(psiElement);
     if (psiClassType == null) {
       return new ArrayList<PsiType>();
+    }
+
+    // Check if @Provides(type=?) pattern (annotation with specified type).
+    PsiAnnotationMemberValue attribValue = findTypeAttributeOfProvidesAnnotation(psiElement);
+    if (attribValue != null) {
+      if (attribValue.textMatches(SET_TYPE)) {
+        // type = SET. Transform the type parameter to the element type.
+        ArrayList<PsiType> result = new ArrayList<PsiType>();
+        result.add(psiClassType);
+        return result;
+      } else if (attribValue.textMatches(MAP_TYPE)) {
+        // TODO(radford): Need to figure out key type for maps.
+        // type = SET or type = MAP. Transform the type parameter to the element type.
+        //ArrayList<PsiType> result = new ArrayList<PsiType>();
+        //result.add(psiKeyType):
+        //result.add(psiClassType);
+        //return result;
+      }
     }
 
     if (PsiConsultantImpl.isLazyOrProvider(getClass(psiClassType))) {

--- a/src/com/squareup/ideaplugin/dagger/handler/ProvidesToInjectHandler.java
+++ b/src/com/squareup/ideaplugin/dagger/handler/ProvidesToInjectHandler.java
@@ -20,7 +20,7 @@ public class ProvidesToInjectHandler implements GutterIconNavigationHandler<PsiE
     }
 
     PsiMethod psiMethod = (PsiMethod) psiElement;
-    PsiClass psiClass = PsiConsultantImpl.getReturnClassFromMethod(psiMethod);
+    PsiClass psiClass = PsiConsultantImpl.getReturnClassFromMethod(psiMethod, true);
 
     new ShowUsagesAction(new Decider.ProvidesMethodDecider(psiMethod)).startFindUsages(psiClass,
         new RelativePoint(mouseEvent), PsiUtilBase.findEditor(psiClass), MAX_USAGES);


### PR DESCRIPTION
This patch fixes fetching the injection points referenced by @Provides(type=SET), and also enables searching for the provider sources of type=SET for when the injected value is of type Set<T>. For example:

    @Inject SomeConstructor(Set<Long> longSet) { ... }
    
Will now be able to resolve to a definition like:
    
    @Provide(type=SET) Long provideSetElement() { return 1L; }

And vice versa.

Details:
- Adds a listener class to ShowUsagesAction that is called when the search result completes. The listener receives a boolean indicating whether results were found or not. This enables chaining additional actions that must be taken after one action completes.
- Adds a CollectionElementParameterInjectDecider that adds an additional constraint to IsAProviderDecider, which is that the method element's @Provide annotation must include a type=SET provider. This class can be used to search only for SET providers.
- Adds a boolean argument to PsiConsultantImpl#getReturnClassFromMethod that when set true, elements annotated with @Provides(type=SET) returns a class type of Set<ELEMENT_TYPE>.
- Updates PsiConsultantImpl#getTypeParameters so that elements annotated with @Provides(type=SET) returns a list with just the method's return type.
- Updates ConstructorInjectToProvidesHandler such that for @Provide with type annotation param set, first check for methods annotated with @Provide(type=SET) that match the search criteria. If search finishes with no results, then resort to original search.